### PR TITLE
Archlinux PKGBUILD fix

### DIFF
--- a/archlinux/PKGBUILD-uniconvertor
+++ b/archlinux/PKGBUILD-uniconvertor
@@ -16,7 +16,7 @@ source=('./TARBALL')
 md5sums=('SKIP')
 
 build() {
-  chmod -R 644 "${srcdir}/$pkgname-$pkgver"
+  chmod -R u+rw,g+r,o+r "${srcdir}/$pkgname-$pkgver"
   cd "${srcdir}/$pkgname-$pkgver"
   LANG=en_US.UTF-8 python2 setup.py build
 }


### PR DESCRIPTION
Corrected recursive permission command in a manner that doesn't clobber the directory executable permission. For the record it built successfully for me when I removed the line altogether, but it will also build with my change.

Fixes issue: https://github.com/sk1project/uniconvertor/issues/38